### PR TITLE
yaml.safeLoad is removed in js-yaml 4

### DIFF
--- a/legacy/bootstrap.js
+++ b/legacy/bootstrap.js
@@ -31,7 +31,7 @@ const loadCacheFile = file => {
  */
 const loadLandoFile = file => {
   try {
-    return yaml.safeLoad(fs.readFileSync(file));
+    return yaml.load(fs.readFileSync(file));
   } catch (e) {
     throw new Error(`There was a problem with parsing ${file}. Ensure it is valid YAML! ${e}`);
   }

--- a/legacy/config.js
+++ b/legacy/config.js
@@ -216,7 +216,7 @@ exports.loadFiles = files => _(files)
   .filter(source => fs.existsSync(source) || fs.existsSync(source.file))
   // If the file is just a string lets map it to an object
   .map(source => {
-    return _.isString(source) ? {file: source, data: yaml.safeLoad(fs.readFileSync(source))} : source;
+    return _.isString(source) ? {file: source, data: yaml.load(fs.readFileSync(source))} : source;
   })
   // Add on the root directory for mapping purposes
   .map(source => _.merge({}, source, {root: path.dirname(source.file)}))

--- a/legacy/yaml.js
+++ b/legacy/yaml.js
@@ -28,7 +28,7 @@ module.exports = class Yaml {
    */
   load(file) {
     try {
-      return yaml.safeLoad(fs.readFileSync(file));
+      return yaml.load(fs.readFileSync(file));
     } catch (e) {
       this.log.error('Problem parsing %s with %s', file, e.message);
     }

--- a/legacy/yaml.js
+++ b/legacy/yaml.js
@@ -49,7 +49,7 @@ module.exports = class Yaml {
     // Remove any properties that might be bad and dump
     data = JSON.parse(JSON.stringify(data));
     // And dump
-    fs.writeFileSync(file, yaml.safeDump(data));
+    fs.writeFileSync(file, yaml.dump(data));
     // Log and return filename
     return file;
   }


### PR DESCRIPTION
I see several open PRs (#32 #38 #39 #40) currently fail unit tests with:

```
  yaml
    #Yaml
      ✔ should return a Yaml instance with correct default options
    #load
ERROR ==> Problem parsing /tmp/config1.yml with Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default. 
      4) should return data from a YAML file as an Object
      ✔ should throw an error when file does not exist
    #dump
      5) should create the directory for the file if it does not exist
      6) should write a valid YAML file to disk for the object
      7) should return the name of the file
```

It may be those PRs are failing due to breakage on the main branch, not due to the proposed changes? PR to see if tests can be fixed with trivia patch.

I'm not certain if this is because PRs from external repos need some additional configuration (if so, I'm not finding docs on setup), or if because an update to [js-yaml](https://www.npmjs.com/package/js-yaml) landed and broke unit tests.

I see the affected files are in a directory `legacy/` which might mean they shouldn't be modified?