### PR TITLE
Pass terminal dimensions into container

### DIFF
--- a/legacy/utils.js
+++ b/legacy/utils.js
@@ -62,9 +62,14 @@ exports.loadComposeFiles = (files, dir) => _(exports.validateFiles(files, dir))
 /*
  * Helper to get default cli envvars
  */
-exports.getCliEnvironment = (more = {}) => _.merge({}, {
-  PHP_MEMORY_LIMIT: '-1',
-}, more);
+exports.getCliEnvironment = (more = {}) => _.merge(
+  {},
+  {PHP_MEMORY_LIMIT: '-1'},
+  // Pass terminal dimensions into the container so that tools that rely on them can render properly
+  process.stdout.columns && {COLUMNS: process.stdout.columns},
+  process.stdout.rows && {LINES: process.stdout.rows},
+  more,
+);
 
 /*
  * Helper to return a valid id from app data


### PR DESCRIPTION
Resolves lando/lando#1847 by grabbing the current terminal dimensions and passing them in with the tooling command at run time via the LINES and COLUMNS env vars. The same fix is applied to legacy core at lando/core#50.